### PR TITLE
Keep shrine purchasable after teleporter

### DIFF
--- a/ArtifactOfPrestige/Artifact.cs
+++ b/ArtifactOfPrestige/Artifact.cs
@@ -12,6 +12,7 @@ using UnityEngine.SceneManagement;
 using static RoR2.TeleporterInteraction;
 using UnityEngine.UIElements;
 using Newtonsoft.Json;
+using UnityEngine.AddressableAssets;
 
 
 namespace ArtifactOfPrestige
@@ -71,6 +72,7 @@ namespace ArtifactOfPrestige
                     ArtifactOfPrestige.bonusRewardCount = dataObj.bonusRewardCount;
                     ArtifactOfPrestige.shrineBonusStacks = dataObj.shrineBonusStacks;
                     ArtifactOfPrestige.NetworkshowExtraBossesIndicator = dataObj.NetworkshowExtraBossesIndicator;
+                    ArtifactOfPrestige.latentShrinesHit = dataObj.latentShrinesHit;
                 }
             }
         }
@@ -83,6 +85,12 @@ namespace ArtifactOfPrestige
                 ArtifactOfPrestige.NetworkshowExtraBossesIndicator = true;
                 Networking.InvokeAddIndicator(ArtifactEnabled);
             }
+            else
+            {
+                // shrines activated after TP are added to the "latent count", which is added to the total at the start of the next stage
+                ArtifactOfPrestige.latentShrinesHit++; 
+                ArtifactOfPrestige.NetworkshowExtraBossesIndicator = true;
+            }
             orig(self);
         }
 
@@ -90,6 +98,10 @@ namespace ArtifactOfPrestige
         {
             ArtifactOfPrestige.localIndicators = [];
             ArtifactOfPrestige.offset = 0;
+
+            ArtifactOfPrestige.bonusRewardCount += ArtifactOfPrestige.latentShrinesHit;
+            ArtifactOfPrestige.shrineBonusStacks += ArtifactOfPrestige.latentShrinesHit;
+            ArtifactOfPrestige.latentShrinesHit = 0;
 
             if (ArtifactOfPrestige.stackOutsidePrestige.Value && !ArtifactEnabled)
             {
@@ -145,6 +157,7 @@ namespace ArtifactOfPrestige
                 ArtifactOfPrestige.ResetValues();
             }
             LoadProperSave(); // loading from ProperSave, if it's active
+            AllowShrineAfterTeleporter(run); // allows shrines to be activated after teleporter is started, if the artifact is enabled
         }
 
         private void SpawnShrine(On.RoR2.SceneDirector.orig_PopulateScene orig, SceneDirector self)
@@ -182,6 +195,21 @@ namespace ArtifactOfPrestige
             ArtifactOfPrestige.offset += 2;
             child.SetActive(true);
             ArtifactOfPrestige.localIndicators.Add(child);
+        }
+
+        private void AllowShrineAfterTeleporter(Run run)
+        {
+            var shrineBossPrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/ShrineBoss/ShrineBoss.prefab").WaitForCompletion();
+            var shrineBossPI = shrineBossPrefab.GetComponent<PurchaseInteraction>();
+            shrineBossPI.setUnavailableOnTeleporterActivated = !ArtifactEnabled;
+
+            var shrineBossSnowPrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/ShrineBoss/ShrineBossSandy Variant.prefab").WaitForCompletion();
+            var shrineBossSnowPI = shrineBossSnowPrefab.GetComponent<PurchaseInteraction>();
+            shrineBossSnowPI.setUnavailableOnTeleporterActivated = !ArtifactEnabled;
+
+            var shrineBossSandPrefab = Addressables.LoadAssetAsync<GameObject>("RoR2/Base/ShrineBoss/ShrineBossSnowy Variant.prefab").WaitForCompletion();
+            var shrineBossSandPI = shrineBossSandPrefab.GetComponent<PurchaseInteraction>();
+            shrineBossSandPI.setUnavailableOnTeleporterActivated = !ArtifactEnabled;
         }
     }
 }

--- a/ArtifactOfPrestige/ArtifactOfPrestige.cs
+++ b/ArtifactOfPrestige/ArtifactOfPrestige.cs
@@ -34,7 +34,7 @@ namespace ArtifactOfPrestige
         public const string PluginGUID = PluginAuthor + "." + PluginName;
         public const string PluginAuthor = "Miyowi";
         public const string PluginName = "ArtifactOfPrestige";
-        public const string PluginVersion = "1.3.1";
+        public const string PluginVersion = "1.3.2";
 
         public static ConfigEntry<bool> stackingIndicators { get; set; }
         public static ConfigEntry<bool> colouredIndicators { get; set; }
@@ -50,7 +50,6 @@ namespace ArtifactOfPrestige
         public static int offset = 0;
         public static bool NetworkshowExtraBossesIndicator = false;
         public static List<GameObject> localIndicators = [];
-        public static int latentShrinesHit = 0;
 
         public void Awake()
         {
@@ -61,7 +60,7 @@ namespace ArtifactOfPrestige
 
             var tmpGo = new GameObject("tmpGo");
             tmpGo.AddComponent<NetworkIdentity>();
-            CentralNetworkObject = tmpGo.InstantiateClone("somethingUnique");
+            CentralNetworkObject = tmpGo.InstantiateClone("mwmwArtifactOfPrestige");
             GameObject.Destroy(tmpGo);
             CentralNetworkObject.AddComponent<Networking>();
 
@@ -106,7 +105,6 @@ namespace ArtifactOfPrestige
             shrineBonusStacks = 0;
             offset = 0;
             NetworkshowExtraBossesIndicator = false;
-            latentShrinesHit = 0;
         }
 
         public bool ValidateArtifact(ArtifactBase artifact, List<ArtifactBase> artifactList)

--- a/ArtifactOfPrestige/ArtifactOfPrestige.cs
+++ b/ArtifactOfPrestige/ArtifactOfPrestige.cs
@@ -50,6 +50,7 @@ namespace ArtifactOfPrestige
         public static int offset = 0;
         public static bool NetworkshowExtraBossesIndicator = false;
         public static List<GameObject> localIndicators = [];
+        public static int latentShrinesHit = 0;
 
         public void Awake()
         {
@@ -105,6 +106,7 @@ namespace ArtifactOfPrestige
             shrineBonusStacks = 0;
             offset = 0;
             NetworkshowExtraBossesIndicator = false;
+            latentShrinesHit = 0;
         }
 
         public bool ValidateArtifact(ArtifactBase artifact, List<ArtifactBase> artifactList)

--- a/ArtifactOfPrestige/Compatibility.cs
+++ b/ArtifactOfPrestige/Compatibility.cs
@@ -85,14 +85,12 @@ namespace ArtifactOfPrestige
         public int bonusRewardCount;
         public int shrineBonusStacks;
         public bool NetworkshowExtraBossesIndicator;
-        public int latentShrinesHit;
 
         public ArtifactOfPrestige_ProperSaveObj()
         {
             this.bonusRewardCount = ArtifactOfPrestige.bonusRewardCount;
             this.shrineBonusStacks = ArtifactOfPrestige.shrineBonusStacks;
             this.NetworkshowExtraBossesIndicator = ArtifactOfPrestige.NetworkshowExtraBossesIndicator;
-            this.latentShrinesHit = ArtifactOfPrestige.latentShrinesHit;
         }
     }
 }

--- a/ArtifactOfPrestige/Compatibility.cs
+++ b/ArtifactOfPrestige/Compatibility.cs
@@ -85,12 +85,14 @@ namespace ArtifactOfPrestige
         public int bonusRewardCount;
         public int shrineBonusStacks;
         public bool NetworkshowExtraBossesIndicator;
+        public int latentShrinesHit;
 
         public ArtifactOfPrestige_ProperSaveObj()
         {
             this.bonusRewardCount = ArtifactOfPrestige.bonusRewardCount;
             this.shrineBonusStacks = ArtifactOfPrestige.shrineBonusStacks;
             this.NetworkshowExtraBossesIndicator = ArtifactOfPrestige.NetworkshowExtraBossesIndicator;
+            this.latentShrinesHit = ArtifactOfPrestige.latentShrinesHit;
         }
     }
 }

--- a/ArtifactOfPrestige/Networking.cs
+++ b/ArtifactOfPrestige/Networking.cs
@@ -32,7 +32,7 @@ namespace ArtifactOfPrestige
             {
                 ArtifactOfPrestige.shrineBonusStacks++;
             }
-            if (ArtifactOfPrestige.shrineBonusStacks > 1 && ArtifactOfPrestige.stackingIndicators.Value)
+            if (TeleporterInteraction.instance?.activationState <= TeleporterInteraction.ActivationState.IdleToCharging && ArtifactOfPrestige.shrineBonusStacks > 1 && ArtifactOfPrestige.stackingIndicators.Value)
             {
                 var instance = TeleporterInteraction.instance;
                 var original = instance.bossShrineIndicator;


### PR DESCRIPTION
When the Artifact of Prestige is active, Shrine of the Mountain will remain available after the teleporter is triggered. Effects are applied at the start of the next stage, reflecting the behavior seen in Risk of Rain Returns.

The shrine still temporarily locks if it is outside of the radius before the teleporter is finished, like other purchasables.

![active_mountain](https://github.com/user-attachments/assets/e6ca67ce-2c21-4019-ae35-b359bb471693)
